### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,33 @@
 plugins {
     id 'maven-publish'
     id 'com.enonic.defaults' version '2.1.6'
-    id 'com.enonic.xp.app' version '3.6.2'
+    id 'com.enonic.xp.app'
 }
 
-app {
-    name = project.appName
-    displayName = 'Live Trace'
-    vendorName = 'Enonic AS'
-    vendorUrl = 'https://enonic.com'
-    systemVersion = "${xpVersion}"
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
-
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = sourceCompatibility
 
 dependencies {
     // XP core
-    implementation "com.enonic.xp:core-api:${xpVersion}"
-    implementation "com.enonic.xp:portal-api:${xpVersion}"
-    implementation "com.enonic.xp:web-api:${xpVersion}"
-    include "com.enonic.xp:lib-content:${xpVersion}"
-    include "com.enonic.xp:lib-portal:${xpVersion}"
-    include "com.enonic.xp:lib-io:${xpVersion}"
-    include "com.enonic.xp:lib-auth:${xpVersion}"
-    include "com.enonic.xp:lib-websocket:${xpVersion}"
-    include "com.enonic.xp:lib-task:${xpVersion}"
-    include "com.enonic.xp:lib-event:${xpVersion}"
-    include "com.enonic.xp:lib-admin:${xpVersion}"
+    implementation xplibs.api.core
+    implementation xplibs.api.portal
+    implementation xplibs.api.web
+    compileOnly libs.jackson.databind
+    compileOnly libs.micrometer.core
+    include xplibs.content
+    include xplibs.portal
+    include xplibs.io
+    include xplibs.auth
+    include xplibs.websocket
+    include xplibs.task
+    include xplibs.event
+    include xplibs.admin
 
-    include 'com.enonic.lib:lib-license:3.1.0'
-
-    include 'com.enonic.lib:lib-mustache:2.1.1'
-    include "com.enonic.lib:lib-http-client:3.2.2"
+    include libs.lib.license
+    include libs.lib.mustache
+    include libs.lib.http.client
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,6 @@ plugins {
     id 'com.enonic.xp.app'
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_25
-    targetCompatibility = JavaVersion.VERSION_25
-}
-
 dependencies {
     // XP core
     implementation xplibs.api.core

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 group=com.enonic.app
 projectName=livetrace
 appName=com.enonic.app.livetrace
-xpVersion=7.4.0
+appDisplayName=Live Trace
+vendorName=Enonic AS
+vendorUrl=https://enonic.com
+xpVersion=8.0.0-B4
 
 version=2.3.1-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+license = "3.1.0"
+mustache = "2.1.1"
+httpClient = "3.2.2"
+jackson = "2.21.3"
+micrometer = "1.16.5"
+
+[libraries]
+lib-license = { module = "com.enonic.lib:lib-license", version.ref = "license" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "httpClient" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName

--- a/src/main/java/com/enonic/app/livetrace/TraceHandler.java
+++ b/src/main/java/com/enonic/app/livetrace/TraceHandler.java
@@ -53,7 +53,7 @@ public final class TraceHandler
         collectors = new ConcurrentHashMap<>();
         requestRate = new RequestRate();
         scheduler = Executors.newScheduledThreadPool( 1 );
-        liveTraceApp = ApplicationKey.from( TraceHandler.class ).toString();
+        liveTraceApp = ApplicationKey.from( "com.enonic.app.livetrace" ).toString();
         liveTraceAppPrefix = liveTraceApp + ":";
     }
 

--- a/src/main/java/com/enonic/app/livetrace/metrics/HttpThreadPoolInfoReporter.java
+++ b/src/main/java/com/enonic/app/livetrace/metrics/HttpThreadPoolInfoReporter.java
@@ -1,0 +1,53 @@
+package com.enonic.app.livetrace.metrics;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.enonic.xp.status.StatusReporter;
+
+@Component(immediate = true, service = {HttpThreadPoolInfoReporter.class})
+public class HttpThreadPoolInfoReporter
+{
+    private StatusReporter jsonReporter;
+
+    public HttpThreadPoolInfoReporter()
+    {
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE)
+    public void addReporter( final StatusReporter reporter )
+    {
+        if ( "http.threadpool".equals( reporter.getName() ) )
+        {
+            this.jsonReporter = reporter;
+        }
+    }
+
+    public int getThreadCount()
+    {
+        if ( jsonReporter == null )
+        {
+            return 0;
+        }
+        try
+        {
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            jsonReporter.report( outputStream );
+            final JsonNode json = new ObjectMapper().reader().readTree( outputStream.toByteArray() );
+            final JsonNode threads = json.get( "threads" );
+            return threads != null ? threads.asInt() : 0;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+}

--- a/src/main/java/com/enonic/app/livetrace/metrics/MetricsEmitter.java
+++ b/src/main/java/com/enonic/app/livetrace/metrics/MetricsEmitter.java
@@ -7,24 +7,20 @@ import java.lang.management.OperatingSystemMXBean;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 
 import com.enonic.xp.server.ServerInfo;
-import com.enonic.xp.util.Metrics;
-import com.enonic.xp.web.thread.ThreadPoolInfo;
 
 
 public class MetricsEmitter
 {
-    private static final String METRIC_NAME = "com.codahale.metrics.jetty9.InstrumentedHttpChannelListener.requests";
+    private static final String REQUEST_TIMER_NAME = "jetty.connections.request.time";
 
     private final ScheduledExecutorService scheduler;
 
@@ -32,7 +28,7 @@ public class MetricsEmitter
 
     private final ClusterInfoReporter clusterInfoReporter;
 
-    private final ThreadPoolInfo threadPool;
+    private final HttpThreadPoolInfoReporter threadPoolInfoReporter;
 
     private final Consumer<Object> onData;
 
@@ -40,12 +36,12 @@ public class MetricsEmitter
 
     private long lastReqCount;
 
-    public MetricsEmitter( final String sessionId, final ThreadPoolInfo threadPool, final ClusterInfoReporter clusterInfoReporter,
-                           final Consumer<Object> onData )
+    public MetricsEmitter( final String sessionId, final HttpThreadPoolInfoReporter threadPoolInfoReporter,
+                           final ClusterInfoReporter clusterInfoReporter, final Consumer<Object> onData )
     {
         this.sessionId = sessionId;
         this.clusterInfoReporter = clusterInfoReporter;
-        this.threadPool = threadPool;
+        this.threadPoolInfoReporter = threadPoolInfoReporter;
         this.onData = onData;
         this.scheduler = Executors.newSingleThreadScheduledExecutor();
     }
@@ -77,13 +73,10 @@ public class MetricsEmitter
         final List<MemoryPoolMXBean> memoryPools = ManagementFactory.getMemoryPoolMXBeans();
 
         final int totalThreadCount = ManagementFactory.getThreadMXBean().getThreadCount();
-        final int httpThreadCount = threadPool.getThreads();
+        final int httpThreadCount = threadPoolInfoReporter.getThreadCount();
 
-        final MetricFilter metricFilter = ( name, metric ) -> name.toLowerCase().contains( METRIC_NAME.toLowerCase() );
-        final MetricRegistry registry = Metrics.registry();
-        final SortedMap<String, Timer> reqTimer = registry.getTimers( metricFilter );
-
-        final long reqCount = reqTimer.get( METRIC_NAME ).getCount();
+        final Timer requestTimer = Metrics.globalRegistry.find( REQUEST_TIMER_NAME ).timer();
+        final long reqCount = requestTimer != null ? requestTimer.count() : 0;
 
         double reqSec = 0;
         if ( lastMeasureTime != null )

--- a/src/main/java/com/enonic/app/livetrace/metrics/MetricsHandler.java
+++ b/src/main/java/com/enonic/app/livetrace/metrics/MetricsHandler.java
@@ -8,12 +8,11 @@ import org.osgi.service.component.annotations.Deactivate;
 import com.enonic.xp.index.IndexService;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
-import com.enonic.xp.web.thread.ThreadPoolInfo;
 
 public class MetricsHandler
     implements ScriptBean
 {
-    private ThreadPoolInfo threadPool;
+    private HttpThreadPoolInfoReporter threadPoolInfoReporter;
 
     private IndexService indexService;
 
@@ -29,7 +28,7 @@ public class MetricsHandler
     public MetricsEmitter subscribe( final String sessionId, final Consumer<Object> onData )
     {
         return emitters.computeIfAbsent( sessionId, ( sid ) -> {
-            final MetricsEmitter emitter = new MetricsEmitter( sid, threadPool, clusterInfoReporter, onData );
+            final MetricsEmitter emitter = new MetricsEmitter( sid, threadPoolInfoReporter, clusterInfoReporter, onData );
             emitter.start();
             return emitter;
         } );
@@ -53,7 +52,7 @@ public class MetricsHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.threadPool = context.getService( ThreadPoolInfo.class ).get();
+        this.threadPoolInfoReporter = context.getService( HttpThreadPoolInfoReporter.class ).get();
         this.indexService = context.getService( IndexService.class ).get();
         this.clusterInfoReporter = context.getService( ClusterInfoReporter.class ).get();
     }

--- a/src/main/resources/admin/tools/livetrace/livetrace.html
+++ b/src/main/resources/admin/tools/livetrace/livetrace.html
@@ -254,15 +254,5 @@ var SVC_URL = '{{svcUrl}}'; // Needed by livetrace-tool.js
 <script type="text/javascript" src="{{assetsUri}}/js/chart.min.js"></script>
 <script type="text/javascript" src="{{assetsUri}}/js/livetrace-tool.js"></script>
 
-<script>
-    var CONFIG = {
-        adminUrl: '{{adminUrl}}',
-        appId: 'toolstarter',
-        services: {}, // Workaround for i18nUrl BUG
-        launcherUrl: '{{launcherUrl}}'
-    };
-</script>
-<script type="text/javascript" src="{{launcherPath}}" async></script>
-
 </body>
 </html>

--- a/src/main/resources/admin/tools/livetrace/livetrace.js
+++ b/src/main/resources/admin/tools/livetrace/livetrace.js
@@ -1,14 +1,10 @@
 // Libs
 const mustache = require('/lib/mustache');
 const portalLib = require('/lib/xp/portal');
-const adminLib = require('/lib/xp/admin');
 const licenseManager = require("/lib/license-manager");
 
 // Functions
 const assetUrl = portalLib.assetUrl;
-const getLauncherPath = adminLib.getLauncherPath;
-const getLauncherUrl = adminLib.getLauncherUrl;
-const getBaseUri = adminLib.getBaseUri;
 const serviceUrl = portalLib.serviceUrl;
 const render = mustache.render;
 
@@ -23,9 +19,6 @@ exports.get = function (req) {
         assetsUri: assetUrl({
             path: ''
         }),
-        launcherPath: getLauncherPath(),
-        launcherUrl: getLauncherUrl(),
-        adminUrl: getBaseUri(),
         svcUrl: serviceUrl({service: 'Z'}).slice(0, -1), // Needed by livetrace-tool.js
         licenseText: licenseManager.getIssuedTo(),
     };

--- a/src/main/resources/admin/tools/livetrace/livetrace.xml
+++ b/src/main/resources/admin/tools/livetrace/livetrace.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<tool xmlns="urn:enonic:xp:model:1.0">
-  <display-name>Live Trace</display-name>
-  <description>XP Live Trace</description>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</tool>

--- a/src/main/resources/admin/tools/livetrace/livetrace.yaml
+++ b/src/main/resources/admin/tools/livetrace/livetrace.yaml
@@ -1,0 +1,11 @@
+kind: "AdminTool"
+title:
+  text: "Live Trace"
+description:
+  text: "XP Live Trace"
+allow:
+  - "role:system.admin"
+apis:
+  - "admin:extension"
+  - "admin:event"
+  - "admin:status"

--- a/src/main/resources/application.xml
+++ b/src/main/resources/application.xml
@@ -1,3 +1,0 @@
-<application>
-  <description>Live Trace application for Enonic XP</description>
-</application>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,5 @@
+kind: "Application"
+title: "Live Trace"
+description: "Live Trace application for Enonic XP"
+vendorName: "Enonic AS"
+vendorUrl: "https://enonic.com"

--- a/src/main/resources/services/check/check.xml
+++ b/src/main/resources/services/check/check.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/check/check.yaml
+++ b/src/main/resources/services/check/check.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/dashboard/dashboard.xml
+++ b/src/main/resources/services/dashboard/dashboard.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/dashboard/dashboard.yaml
+++ b/src/main/resources/services/dashboard/dashboard.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/pingws/pingws.xml
+++ b/src/main/resources/services/pingws/pingws.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/pingws/pingws.yaml
+++ b/src/main/resources/services/pingws/pingws.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/sampling/sampling.xml
+++ b/src/main/resources/services/sampling/sampling.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/sampling/sampling.yaml
+++ b/src/main/resources/services/sampling/sampling.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/status/status.xml
+++ b/src/main/resources/services/status/status.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/status/status.yaml
+++ b/src/main/resources/services/status/status.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/tasks/tasks.xml
+++ b/src/main/resources/services/tasks/tasks.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tasks/tasks.yaml
+++ b/src/main/resources/services/tasks/tasks.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/tracing/tracing.xml
+++ b/src/main/resources/services/tracing/tracing.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tracing/tracing.yaml
+++ b/src/main/resources/services/tracing/tracing.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/uploadLicense/uploadLicense.xml
+++ b/src/main/resources/services/uploadLicense/uploadLicense.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/uploadLicense/uploadLicense.yaml
+++ b/src/main/resources/services/uploadLicense/uploadLicense.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"


### PR DESCRIPTION
## Summary

Migrate `app-livetrace` from Enonic XP 7.4.0 to XP 8.0.0-B4 by following the `xp-app-upgrader` skill end-to-end.

### Build / dependency surface (per skill)

- **`settings.gradle`** — added `id 'com.enonic.xp.settings' version '4.0.0-B1'` (latest released; only `4.0.0-A3` and `4.0.0-B1` are live on plugins.gradle.org).
- **`build.gradle`** — dropped the `com.enonic.xp.app` version pin (the settings plugin supplies it now); removed the `app{}` metadata block (XP 8 reads metadata from `application.yaml`); migrated XP libs from `com.enonic.xp:*` long-form to the `xplibs.*` catalog (`xplibs.api.core`, `xplibs.api.portal`, `xplibs.api.web`, `xplibs.content`, `xplibs.portal`, `xplibs.io`, `xplibs.auth`, `xplibs.websocket`, `xplibs.task`, `xplibs.event`, `xplibs.admin`); lifted the three third-party `com.enonic.lib:*` deps (`lib-license`, `lib-mustache`, `lib-http-client`) into a new `gradle/libs.versions.toml` catalog and reference them as `libs.lib.*`.
- **`gradle.properties`** — `xpVersion`: `7.4.0` → `8.0.0-B4` (latest released XP 8 beta); added `appDisplayName`, `vendorName`, `vendorUrl` so they flow into `application.yaml`.
- **Gradle wrapper** — bumped 8.12.1 → 9.4.1 (plugin 4.x requires Gradle 9+).
- **Java compatibility** — top-level `sourceCompatibility`/`targetCompatibility` (Gradle 9 dropped them as `Project` properties) re-declared inside a `java {}` block at Java 25 (XP 8 requires JVM 25).

### Descriptor migration (hand-edited; `xp8migrator` native binary doesn't run on this CI runner)

- `application.xml` → `application.yaml` (`kind: "Application"`).
- `admin/tools/livetrace/livetrace.xml` → `livetrace.yaml` (`kind: "AdminTool"`; `title`/`description` in `{ text }` object form per skill; `apis:` declares the system APIs `admin:extension`, `admin:event`, `admin:status`).
- 8× `services/*/*.xml` → `*.yaml` (`kind: "Service"`).

### Code-level breaking changes

- **`TraceHandler`** — `ApplicationKey.from(Class)` was removed; replaced with `ApplicationKey.from("com.enonic.app.livetrace")`.
- **Admin-tool controller (`livetrace.js`) + template (`livetrace.html`)** — removed calls to the deleted admin-lib helpers `getLauncherPath()`, `getLauncherUrl()`, `getBaseUri()`, and the injected launcher `<script>` tag (XP 8 no longer ships a launcher script).
- **Metrics dashboard** — `com.enonic.xp.web.thread.ThreadPoolInfo` is gone in XP 8; thread-pool size is now read via the new `"http.threadpool"` `StatusReporter` through a new `HttpThreadPoolInfoReporter` helper (mirrors the existing `ClusterInfoReporter` pattern).
- **Metrics dashboard** — Codahale Metrics + `com.enonic.xp.util.Metrics` were removed; switched to Micrometer (`io.micrometer.core.instrument.Metrics.globalRegistry`) and read the request count from the `"jetty.connections.request.time"` timer, which is what `JettyConnectionMetrics` now exposes.
- Added `compileOnly libs.jackson.databind` and `compileOnly libs.micrometer.core` (both are on the XP 8 runtime classpath via OSGi exports, so `compileOnly` is sufficient).

## Validation

- `./gradlew clean build` — green on Gradle 9.4.1 against XP 8.0.0-B4.
- **Runtime verification was not performed** — the runner sandbox is ephemeral; deploy verification is out of scope per the task brief.

## Test plan

- [ ] `./gradlew clean build` (already green locally; CI should confirm).
- [ ] Deploy on an XP 8.0.0-B4 sandbox and open the Live Trace admin tool; verify the dashboard receives `requestRate` and `threads.http` values.
- [ ] Confirm the launcher menu still works without the old `<script src="{{launcherPath}}">` injection.