### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "2.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ vendorName=Enonic AS
 vendorUrl=https://enonic.com
 xpVersion=8.0.0-B4
 
-version=2.3.1-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump master `version` to `3.0.0-SNAPSHOT` (was `2.3.1-SNAPSHOT`) for the XP 8 line.
- Configure `enonic/release-tools/build-and-publish` with `releaseBranch:` listing both `master` and `2.x` so the action recognizes them as release branches.
- Add `2.x` to `enonic-docgen.yml` push branches.
- Seed `docs/versions.json` so docs publish `stable` from `2.x` and `next` from `master`.

The companion `2.x` maintenance branch was created from `96dfae3` (the post-`v2.3.0-B1` "Updated to next SNAPSHOT version" commit) and ships its own CI-config PR so pushes to `2.x` are recognized as release-branch builds.

## Test plan
- [ ] CI run on this branch is green.
- [ ] After merge: `./gradlew clean build` from `master` is green.
- [ ] After merge of the companion `2.x` PR: a CI run on `2.x` classifies it as a release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)