### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a `releaseBranch:` block under `enonic/release-tools/build-and-publish` listing both `master` and `2.x`, so pushes to this maintenance branch are recognized as release-branch builds.

This is the maintenance-branch companion to the master PR that bumps `master` to `3.0.0-SNAPSHOT` for XP 8 (#83). The action reads `releaseBranch:` from the workflow file on the branch being pushed, so the same block has to land on `2.x` as well.

Per the migration recipe (mirroring app-booster), only the CI config changes on `2.x`. No version bump, no docgen change, no `versions.json` here — those are master-only.

## Test plan
- [ ] CI run on this branch is green.
- [ ] After merge: a CI run on `2.x` classifies it as a release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)