### PR TITLE
Bump enonic libs to XP 8 SNAPSHOTs #86

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ dependencies {
 
 repositories {
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-license = "3.1.0"
-mustache = "2.1.1"
-httpClient = "3.2.2"
+license = "4.0.0-SNAPSHOT"
+mustache = "3.0.0-SNAPSHOT"
+httpClient = "4.0.0-SNAPSHOT"
 jackson = "2.21.3"
 micrometer = "1.16.5"
 


### PR DESCRIPTION
Closes #86.

XP 8 E2E verification (issue #86) found `lib-license` 3.1.0 fails at runtime against XP 8 — `LicenseManagerImpl.<clinit>` throws `NoSuchMethodError` on `NodePath.create(NodePath, String)`. Bumping to the published 4.0.0-SNAPSHOT line fixes it. Companion bumps for `lib-mustache` and `lib-http-client` come from the same XP 8 lib release wave.

- `lib-license` 3.1.0 → 4.0.0-SNAPSHOT
- `lib-mustache` 2.1.1 → 3.0.0-SNAPSHOT
- `lib-http-client` 3.2.2 → 4.0.0-SNAPSHOT
- `xp.enonicRepo()` → `xp.enonicRepo('dev')` so Gradle can resolve the SNAPSHOTs from `repo.enonic.com/dev`.

## Verification

Built `xp-distro` 8.0.0-B4, deployed the jar into `home/deploy/`, and confirmed:

- bundle reaches ACTIVE — `Started application com.enonic.app.livetrace bundle 117`
- `TraceHandler` initialises — `Live Trace maximum tracing time is 30 minutes.`
- no ERROR / Exception / NoSuchMethod / ClassNotFound / NoClassDefFound entries in `server.log`
- admin tool URL `/admin/livetrace/livetrace` returns 401 + login form (route registered, auth-gated as expected)
- `/_/asset/com.enonic.app.livetrace/css/livetrace.css` serves the app's CSS (200, 21233 bytes)