### PR TITLE
Migrate to lib-asset #88

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     include xplibs.event
     include xplibs.admin
 
+    include libs.lib.asset
     include libs.lib.license
     include libs.lib.mustache
     include libs.lib.http.client

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+asset = "2.0.0-SNAPSHOT"
 license = "4.0.0-SNAPSHOT"
 mustache = "3.0.0-SNAPSHOT"
 httpClient = "4.0.0-SNAPSHOT"
@@ -6,6 +7,7 @@ jackson = "2.21.3"
 micrometer = "1.16.5"
 
 [libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "license" }
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "httpClient" }

--- a/src/main/resources/admin/tools/livetrace/livetrace.js
+++ b/src/main/resources/admin/tools/livetrace/livetrace.js
@@ -1,10 +1,11 @@
 // Libs
 const mustache = require('/lib/mustache');
 const portalLib = require('/lib/xp/portal');
+const assetLib = require('/lib/enonic/asset');
 const licenseManager = require("/lib/license-manager");
 
 // Functions
-const assetUrl = portalLib.assetUrl;
+const assetUrl = assetLib.assetUrl;
 const serviceUrl = portalLib.serviceUrl;
 const render = mustache.render;
 

--- a/src/main/resources/admin/tools/livetrace/livetrace.yaml
+++ b/src/main/resources/admin/tools/livetrace/livetrace.yaml
@@ -6,6 +6,7 @@ description:
 allow:
   - "role:system.admin"
 apis:
+  - "asset"
   - "admin:extension"
   - "admin:event"
   - "admin:status"


### PR DESCRIPTION
Closes #88

Replace `portal.assetUrl` (deprecated in lib-portal) with `lib-asset.assetUrl` in the admin tool.

## Descriptor registration

- `src/main/resources/admin/tools/livetrace/livetrace.yaml` — added `"asset"` to `apis:`.

## Files touched

- `build.gradle` — added `include libs.lib.asset`.
- `gradle/libs.versions.toml` — added `asset = "2.0.0-SNAPSHOT"` and the matching `lib-asset` library entry.
- `src/main/resources/admin/tools/livetrace/livetrace.js` — `require('/lib/enonic/asset')` and call its `assetUrl`.
- `src/main/resources/admin/tools/livetrace/livetrace.yaml` — registered the `asset` API.

`portalLib` import remains in place because the file still uses `portalLib.serviceUrl`.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] Local XP 8 runtime (xp-distro `/tmp/xp-e2e-*` flow): app bundle reaches ACTIVE.
- [x] `GET /admin/com.enonic.app.livetrace/livetrace` (authenticated as `su`) returns 200 with asset URLs in the form `/admin/com.enonic.app.livetrace/livetrace/_/com.enonic.app.livetrace:asset/<fingerprint>/<path>`.
- [x] Each rendered asset URL returns HTTP 200 with non-empty payload (verified for `css/livetrace.css`, `css/opentip.css`, `img/livetrace.svg`, `js/livetrace-tool.js`, `js/chart.min.js`).