### PR TITLE
GraalJS Compatibility #99

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,31 @@ dependencies {
     include libs.lib.license
     include libs.lib.mustache
     include libs.lib.http.client
+    include libs.lib.cron
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
     mavenCentral()
     xp.enonicRepo('dev')
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -41,14 +40,6 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ appName=com.enonic.app.livetrace
 appDisplayName=Live Trace
 vendorName=Enonic AS
 vendorUrl=https://enonic.com
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 
 version=3.0.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,13 @@ asset = "2.0.1"
 license = "4.0.0"
 mustache = "3.0.0"
 httpClient = "4.0.0"
+cron = "2.0.0"
 jackson = "2.22.1"
 micrometer = "1.17.0"
 
 [libraries]
 lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-cron = { module = "com.enonic.lib:lib-cron", version.ref = "cron" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "license" }
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "httpClient" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -1,0 +1,11 @@
+var cronLib = require('/lib/cron');
+var samplingLib = require('/services/sampling/sampling');
+
+cronLib.schedule({
+    name: 'livetrace-request-broadcast',
+    fixedDelay: 1000,
+    callback: function () {
+        samplingLib.broadcastRequestRate();
+        samplingLib.broadcastRequestsSampled();
+    }
+});

--- a/src/main/resources/services/sampling/sampling.js
+++ b/src/main/resources/services/sampling/sampling.js
@@ -1,11 +1,7 @@
 var traceLib = require('/lib/livetrace');
 var webSocketLib = require('/lib/xp/websocket');
-var taskLib = require('/lib/xp/task');
 
 var WS_GROUP_NAME = 'ws-requests';
-var REQUEST_BROADCAST_TASK = 'task-livetrace-request-broadcast';
-
-var broadcastRequestTaskId;
 
 var handleGet = function (req) {
     if (!req.webSocket) {
@@ -14,7 +10,6 @@ var handleGet = function (req) {
         };
     }
 
-    setupRequestRateTask();
     return {
         webSocket: {
             data: {},
@@ -24,55 +19,26 @@ var handleGet = function (req) {
 };
 
 var broadcastRequestRate = function () {
+    if (webSocketLib.getGroupSize(WS_GROUP_NAME) === 0) {
+        return;
+    }
+
     var reqSec = traceLib.getRequestsPerSecond();
     var msg = JSON.stringify({reqSec: reqSec});
     webSocketLib.sendToGroup(WS_GROUP_NAME, msg);
 };
 
 var broadcastRequestsSampled = function () {
+    if (webSocketLib.getGroupSize(WS_GROUP_NAME) === 0) {
+        return;
+    }
+
     var samplingCount = traceLib.getRequestsCount();
 
     if (Object.keys(samplingCount).length > 0) {
         var msg = JSON.stringify({"samplingCount": samplingCount});
         webSocketLib.sendToGroup(WS_GROUP_NAME, msg);
     }
-};
-
-var setupRequestRateTask = function () {
-    var tasks = taskLib.list();
-    var taskRunning = false, task;
-    for (var i = 0; i < tasks.length; i++) {
-        task = tasks[i];
-        if (task.description === REQUEST_BROADCAST_TASK && task.state === 'RUNNING') {
-            taskRunning = true;
-            break;
-        }
-    }
-    if (taskRunning) {
-        log.info('Broadcasting request-rate task already running');
-        return;
-    }
-
-    log.info('Launching broadcasting request-rate task');
-    var shutdownRequest = false;
-    broadcastRequestTaskId = taskLib.submit({
-        description: REQUEST_BROADCAST_TASK,
-        task: function (id) {
-            do {
-                broadcastRequestRate();
-                broadcastRequestsSampled();
-                taskLib.sleep(1000);
-            } while (!shutdownRequest);
-            log.info('Broadcasting request-rate task terminated');
-        }
-    });
-
-    __.disposer(function () {
-        log.info('Application ' + app.name + ' shutting down');
-        shutdownRequest = true;
-        taskLib.sleep(200);
-        broadcastRequestTaskId = undefined;
-    });
 };
 
 var handleWebSocket = function (event) {
@@ -94,3 +60,5 @@ var handleWebSocket = function (event) {
 
 exports.get = handleGet;
 exports.webSocketEvent = handleWebSocket;
+exports.broadcastRequestRate = broadcastRequestRate;
+exports.broadcastRequestsSampled = broadcastRequestsSampled;

--- a/src/test/java/com/enonic/app/livetrace/SamplingScriptTest.java
+++ b/src/test/java/com/enonic/app/livetrace/SamplingScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.livetrace;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class SamplingScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/sampling-test.js";
+    }
+}

--- a/src/test/resources/test/sampling-test.js
+++ b/src/test/resources/test/sampling-test.js
@@ -1,0 +1,70 @@
+var t = require('/lib/xp/testing');
+
+var state = {
+    groupSize: 0,
+    sent: [],
+    scheduled: []
+};
+
+t.mock('/lib/xp/websocket', {
+    getGroupSize: function () {
+        return state.groupSize;
+    },
+    sendToGroup: function (group, message) {
+        state.sent.push({group: group, message: message});
+    },
+    addToGroup: function () {
+    },
+    removeFromGroup: function () {
+    }
+});
+
+t.mock('/lib/livetrace', {
+    getRequestsPerSecond: function () {
+        return 42;
+    },
+    getRequestsCount: function () {
+        return {'GET /site': 5};
+    }
+});
+
+t.mock('/lib/cron', {
+    schedule: function (params) {
+        state.scheduled.push(params);
+    }
+});
+
+require('/main.js');
+
+exports.testSchedulesBroadcastJobFromMain = function () {
+    t.assertEquals(1, state.scheduled.length, 'a single broadcast job should be scheduled from main.js');
+
+    var job = state.scheduled[0];
+    t.assertEquals('livetrace-request-broadcast', job.name, 'job name');
+    t.assertEquals(1000, job.fixedDelay, 'job runs with a 1s fixed delay');
+    t.assertTrue(typeof job.callback === 'function', 'job callback is a function');
+};
+
+exports.testBroadcastsWhenClientsConnected = function () {
+    state.groupSize = 2;
+    state.sent = [];
+
+    state.scheduled[0].callback();
+
+    t.assertEquals(2, state.sent.length, 'request-rate and sampled counts are both broadcast');
+
+    var rate = JSON.parse(state.sent[0].message);
+    t.assertEquals(42, rate.reqSec, 'request-rate value');
+
+    var sampled = JSON.parse(state.sent[1].message);
+    t.assertJsonEquals({'GET /site': 5}, sampled.samplingCount, 'sampled request counts');
+};
+
+exports.testSkipsBroadcastWhenNobodyWatching = function () {
+    state.groupSize = 0;
+    state.sent = [];
+
+    state.scheduled[0].callback();
+
+    t.assertEquals(0, state.sent.length, 'nothing is broadcast when the websocket group is empty');
+};


### PR DESCRIPTION
Fixes #99

## What

Migrates `services/sampling/sampling.js` off the Nashorn-only pattern that GraalJS cannot run, and adds a dual-engine test.

### `sampling.js` / `main.js`
The request-rate broadcaster used to be launched from every websocket handshake via `taskLib.submit({task: fn})`, and stopped by flipping a shared `shutdownRequest` flag from an `__.disposer`. That relies on:
- passing a JS closure to run on another thread (`taskLib.submit` = legacy `task.executeFunction`),
- cross-thread mutable guest state (`shutdownRequest`),
- an `__.disposer` registered off the request path (ignored on pooled engines),
- re-registration on every handshake.

None of these are honored by GraalJS. Replaced with a `lib-cron` job scheduled once from `main.js` (bootstrap context) with a 1s `fixedDelay` that calls `broadcastRequestRate()` and `broadcastRequestsSampled()`. Both functions now return immediately when the websocket group is empty, so there is no cost when nobody is watching. `setupRequestRateTask()`, the `do/while` loop, `shutdownRequest` and the `__.disposer` are gone — the job dies with the application.

### Build / tests
- `lib-cron` `2.0.0` added and bundled (`include`).
- Dual-engine test setup: `test` runs on Nashorn, `testGraalJs` runs the same specs with `xp.script-engine=GraalJS`; `check` depends on both.
- New `SamplingScriptTest` + `test/sampling-test.js` cover: the job is scheduled once from `main.js`, it broadcasts request-rate and sampled counts when clients are connected, and broadcasts nothing when the group is empty.

## CI note

This needs the `ScriptRunnerSupport` fix from enonic/xp#12198, so `xpVersion` is bumped to `8.1.0-SNAPSHOT` (from `xp.enonicRepo('dev')`). **CI `testGraalJs` stays red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — hence draft. Verified locally against a `publishToMavenLocal` build of that branch (GraalVM CE 25): `test` and `testGraalJs` both green, 3 tests each.

Reference (same shape of change): enonic/lib-sql#154.